### PR TITLE
Fix pre-bundling issue by updating Vite config

### DIFF
--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -1,18 +1,6 @@
 import { compile } from "percival-wasm";
 import Worker from "./runtime.worker?worker&inline";
 
-// Needed to fix dependency pre-bundling issue in mocha-vite-puppeteer.
-//
-// The following lines are necessary because these libraries are not present in
-// the non-worker bundle. This makes tests get confused because they discover
-// the library mid-execution and reload the page, breaking Puppeteer.
-//
-// The extra imports do not affect performance or bundle size because of
-// automatic tree-shaking optimizations.
-import "immutable";
-import "d3-dsv";
-import "chai";
-
 interface CancellablePromise<T> extends Promise<T> {
   cancel: () => void;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,9 @@ export default defineConfig({
     },
   },
   plugins: [svelte(), lezer()],
+  optimizeDeps: {
+    entries: ["index.html", "src/**/*.{test,worker}.{js,ts}"],
+  },
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
Previously, I was using a hack in `runtime.ts`, adding some lines that were necessary because certain libraries were not present in the non-worker bundle. This makes tests get confused because they discover the libraries mid-execution and reload the page, breaking Puppeteer.

By updating the `optimizeDeps` config option of Vite, I can tell Vite which entry points to crawl for pre-bundled dependencies at boot time, avoiding this reloading issue entirely.