### PR TITLE
Adjust Divider UX

### DIFF
--- a/src/components/cell/Cell.svelte
+++ b/src/components/cell/Cell.svelte
@@ -39,7 +39,8 @@
 
 <style lang="postcss">
   .cell {
-    @apply relative min-h-[32px];
+    @apply relative min-h-[32px] my-0;
+    /* @apply border border-dotted border-red-500; */
   }
 
   .cell:hover .sidebar {

--- a/src/components/cell/Cell.svelte
+++ b/src/components/cell/Cell.svelte
@@ -40,7 +40,6 @@
 <style lang="postcss">
   .cell {
     @apply relative min-h-[32px] my-0;
-    /* @apply border border-dotted border-red-500; */
   }
 
   .cell:hover .sidebar {

--- a/src/components/cell/CellDivider.svelte
+++ b/src/components/cell/CellDivider.svelte
@@ -25,8 +25,10 @@
 
 <style lang="postcss">
   .divider {
-    @apply h-2 relative flex justify-center items-center transition-opacity
+    z-index: 10;
+    @apply -my-1 py-1 relative flex justify-center items-center transition-opacity
       opacity-0 hover:opacity-100 focus:opacity-100;
+    /* @apply border border-dotted border-red-500; */
   }
 
   .divider.visible {

--- a/src/components/cell/CellDivider.svelte
+++ b/src/components/cell/CellDivider.svelte
@@ -14,21 +14,20 @@
 </script>
 
 <div class="divider" class:visible>
+  <hr />
   {#each types as { type, label }}
     <button on:click={() => dispatch("create", { type })} tabindex="-1">
       <div class="h-3 w-3 mr-[4px]"><FaPlus /></div>
       <span>{label}</span>
     </button>
   {/each}
-  <hr />
 </div>
 
 <style lang="postcss">
   .divider {
     z-index: 10;
     @apply -my-1 py-1 relative flex justify-center items-center transition-opacity
-      opacity-0 hover:opacity-100 focus:opacity-100;
-    /* @apply border border-dotted border-red-500; */
+      space-x-4 opacity-0 hover:opacity-100 focus:opacity-100;
   }
 
   .divider.visible {
@@ -42,9 +41,5 @@
   .divider > button {
     @apply flex items-center bg-white z-10 px-2.5 py-1 text-xs rounded-md shadow
       transition-colors hover:bg-gray-50 active:bg-gray-200;
-  }
-
-  .divider > button:not(:first-child) {
-    @apply ml-4;
   }
 </style>

--- a/src/components/cell/CellDivider.svelte
+++ b/src/components/cell/CellDivider.svelte
@@ -5,30 +5,22 @@
   const dispatch = createEventDispatcher();
 
   export let visible: boolean = false;
+
+  const types = [
+    { type: "code", label: "Code Cell" },
+    { type: "markdown", label: "Markdown Cell" },
+    { type: "plot", label: "Plot Cell" },
+  ];
 </script>
 
 <div class="divider" class:visible>
+  {#each types as { type, label }}
+    <button on:click={() => dispatch("create", { type })} tabindex="-1">
+      <div class="h-3 w-3 mr-[4px]"><FaPlus /></div>
+      <span>{label}</span>
+    </button>
+  {/each}
   <hr />
-  <button on:click={() => dispatch("create", { type: "code" })} tabindex="-1">
-    <div class="h-3 w-3 mr-[4px]"><FaPlus /></div>
-    <span>Code Cell</span>
-  </button>
-  <button
-    on:click={() => dispatch("create", { type: "markdown" })}
-    tabindex="-1"
-    class="ml-4"
-  >
-    <div class="h-3 w-3 mr-[4px]"><FaPlus /></div>
-    <span>Markdown Cell</span>
-  </button>
-  <button
-    on:click={() => dispatch("create", { type: "plot" })}
-    tabindex="-1"
-    class="ml-4"
-  >
-    <div class="h-3 w-3 mr-[4px]"><FaPlus /></div>
-    <span>Plot Cell</span>
-  </button>
 </div>
 
 <style lang="postcss">
@@ -48,5 +40,9 @@
   .divider > button {
     @apply flex items-center bg-white z-10 px-2.5 py-1 text-xs rounded-md shadow
       transition-colors hover:bg-gray-50 active:bg-gray-200;
+  }
+
+  .divider > button:not(:first-child) {
+    @apply ml-4;
   }
 </style>


### PR DESCRIPTION
Hi, nice project! Datalog/prolog-like facts+rules is a great way to work with data, web-based notebooks are an ideal experience for exploring and sharing it, and I've been interested in trying out svelte + tailwindcss, so your project is surprisingly synchronous for me. Thank you for sharing it!

While exploring the project I noticed a couple small things so I fixed them and put them in separate commits for you to review:

Smaller one first: I factored the divider buttons to generate from a list. This should make it easier to add/remove buttons for new types of cells in the future and I think it's a tiny bit easier to read (also maybe an opportunity to generate from centrally registered cell types in some future version?). This is my first time using Svelte so I wanted to poke some (very!) minor low-hanging fruit first. 😸  Note that I moved the `<hr>` to the bottom of the div to reproduce identical button classes with `:not(:first-child)`; I believe the result is the same.

Second, I noticed that you had to be unusually precise to trigger the opacity hover in order to see the divider buttons, in fact I was confused for a few minutes trying to figure out how to add new cells before I discovered that you just have to hover in the right place. So I adjusted the styles to make the divider hover target easier to activate, specifically:

* Remove CellDivider h-2 so the div takes up the whole space between cells
* Remove margin on Cells
* Use negative margin on divider to slightly overlap neighboring cells'
  padding. Keeps both compact spacing and easy hover target.
* Increase divider z-index so the overlap works correctly

With some added borders to visualize, before:

![image](https://user-images.githubusercontent.com/133882/165660131-203d592e-2035-46e3-a52f-47968a842dc1.png)

Here you can see that you have to hover the buttons directly or that tiny sliver around the `<hr>` for the buttons to become visible.

After:

![image](https://user-images.githubusercontent.com/133882/165660387-9a0604a3-ad36-45c6-830b-03ebe8289ad2.png)

Now, hovering anywhere on the overlapped area triggers the hover effect of the divider which makes it much easier to find. I checked and none of the regular cells use this area so this change shouldn't impede their functionality. This does have a small effect on the vertical spacing of neighboring cells (3% taller based on the screenshots), but it is not very noticeable and worth the UX imo.

I'm sorry for writing so many words for such a small PR but I don't have time to make it shorter, please forgive me! 😅🙏 What do you think?