### PR TITLE
Plot cell: allow async, multiple inputs, one output

### DIFF
--- a/src/components/cell/output/FullView.svelte
+++ b/src/components/cell/output/FullView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { RelationSet } from "@/lib/types";
+  import type { RelationSet } from "@/lib/types";
 
   import RelationView from "./RelationView.svelte";
 

--- a/src/components/cell/output/FullView.svelte
+++ b/src/components/cell/output/FullView.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+import type { RelationSet } from "@/lib/types";
+
   import RelationView from "./RelationView.svelte";
 
-  export let value: Record<string, object[]>;
+  export let value: RelationSet;
 </script>
 
 <div class="flex flex-col space-y-3">

--- a/src/components/cell/output/PlotView.svelte
+++ b/src/components/cell/output/PlotView.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-  export let value: string;
+import { isRenderedElement } from "@/lib/types";
+
+
+  export let value: unknown;
 </script>
 
 {#if value}
-  <div class="plot">{@html value}</div>
+{#if isRenderedElement(value)}
+  <div class="plot">{@html value.outerHTML}</div>
+{:else}
+  <div>{JSON.stringify(value)}</div>
+{/if}
 {:else}
   <span class="italic text-sm font-light">(fresh pixels for a plot...)</span>
 {/if}

--- a/src/components/cell/output/PlotView.svelte
+++ b/src/components/cell/output/PlotView.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
-import { isRenderedElement } from "@/lib/types";
-
+  import { isRenderedElement } from "@/lib/types";
 
   export let value: unknown;
 </script>
 
 {#if value}
-{#if isRenderedElement(value)}
-  <div class="plot">{@html value.outerHTML}</div>
-{:else}
-  <div>{JSON.stringify(value)}</div>
-{/if}
+  {#if isRenderedElement(value)}
+    <div class="plot">{@html value.outerHTML}</div>
+  {:else}
+    <div>{JSON.stringify(value)}</div>
+  {/if}
 {:else}
   <span class="italic text-sm font-light">(fresh pixels for a plot...)</span>
 {/if}

--- a/src/components/cell/output/RelationView.svelte
+++ b/src/components/cell/output/RelationView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Relation } from "@/lib/types";
+  import type { Relation } from "@/lib/types";
 
   import ValueView from "./ValueView.svelte";
 

--- a/src/components/cell/output/RelationView.svelte
+++ b/src/components/cell/output/RelationView.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+import type { Relation } from "@/lib/types";
+
   import ValueView from "./ValueView.svelte";
 
   export let name: string;
-  export let values: object[];
+  export let values: Relation;
 
   let displaying = 0;
   $: displaying = Math.min(values.length, 5); // hide long lists

--- a/src/lib/notebook.ts
+++ b/src/lib/notebook.ts
@@ -3,6 +3,7 @@ import { build } from "./runtime";
 import type { CompilerResult } from "./runtime";
 import { buildPlot } from "./plot";
 import type { PlotResult } from "./plot";
+import type { RelationSet } from "./types";
 
 export type MarkdownCell = {
   type: "markdown";
@@ -27,7 +28,7 @@ export type CellData = MarkdownCell | CodeCellData | PlotCellData;
 export type CodeCellState = CodeCellData & {
   result: CompilerResult;
   status: "stale" | "pending" | "done";
-  output?: Record<string, object[]>;
+  output?: RelationSet;
   graphErrors?: string;
   runtimeErrors?: string;
   evaluateHandle?: () => void;
@@ -36,7 +37,7 @@ export type CodeCellState = CodeCellData & {
 export type PlotCellState = PlotCellData & {
   result: PlotResult;
   status: "stale" | "pending" | "done";
-  output?: string;
+  output?: unknown;
   graphErrors?: string;
   runtimeErrors?: string;
   evaluateHandle?: () => void;
@@ -211,7 +212,7 @@ export class NotebookState {
         cell.status === "stale"
       ) {
         let depsOk = true;
-        const deps: Record<string, object[]> = {};
+        const deps: RelationSet = {};
         for (const relation of cell.result.deps) {
           const cellIds = creators.get(relation);
           if (!cellIds || cellIds.length != 1) {
@@ -254,7 +255,8 @@ export class NotebookState {
                 }
               });
           } else {
-            const promise = cell.result.evaluate(deps[cell.result.deps[0]]);
+            const depValues = cell.result.deps.map((dep) => deps[dep]);
+            const promise = cell.result.evaluate(depValues);
             cell.evaluateHandle = () => promise.cancel();
             promise
               .then((figure) => {

--- a/src/lib/notebook.ts
+++ b/src/lib/notebook.ts
@@ -3,7 +3,7 @@ import { build } from "./runtime";
 import type { CompilerResult } from "./runtime";
 import { buildPlot } from "./plot";
 import type { PlotResult } from "./plot";
-import type { RelationSet } from "./types";
+import type { Relation, RelationSet } from "./types";
 
 export type MarkdownCell = {
   type: "markdown";
@@ -170,7 +170,7 @@ export class NotebookState {
       if (cell.graphErrors !== undefined) {
         delete cell.graphErrors;
       }
-      if (cell.result.ok && cell.type === "code") {
+      if (cell.result.ok && cell.result.results.length > 0) {
         for (const relation of cell.result.results) {
           const array = creators.get(relation) ?? [];
           array.push(id);
@@ -184,7 +184,7 @@ export class NotebookState {
       if (cellIds.length > 1) {
         for (const id of cellIds) {
           const cell = this.getCell(id);
-          if (cell.type !== "code") throw new Error("unreachable");
+          if (cell.type === "markdown") throw new Error("unreachable");
           clear(cell, "stale");
           cell.graphErrors = `Relation "${relation}" is defined in multiple cells.`;
         }
@@ -220,15 +220,21 @@ export class NotebookState {
             break;
           }
           const prev = this.getCell(cellIds[0]);
-          if (prev.type !== "code") throw new Error("unreachable");
+          if (prev.type === "markdown") throw new Error("unreachable");
           if (
             prev.status === "done" &&
             prev.result.ok &&
             prev.graphErrors === undefined &&
-            prev.runtimeErrors === undefined &&
-            prev.output?.[relation]
+            prev.runtimeErrors === undefined
           ) {
-            deps[relation] = prev.output[relation];
+            if (prev.type === "code" && prev.output?.[relation]) {
+              deps[relation] = prev.output[relation];
+            } else if (prev.type === "plot" && prev.output !== undefined) {
+              deps[relation] = prev.output as Relation;
+            } else {
+              depsOk = false;
+              break;
+            }
           } else {
             depsOk = false;
             break;
@@ -258,11 +264,12 @@ export class NotebookState {
             const depValues = cell.result.deps.map((dep) => deps[dep]);
             const promise = cell.result.evaluate(depValues);
             cell.evaluateHandle = () => promise.cancel();
+            const results = cell.result.results; // storing for async callback
             promise
               .then((figure) => {
                 cell.output = figure;
                 cell.status = "done";
-                this.revalidate();
+                this.markUpdate(results);
               })
               .catch((err: Error) => {
                 if (err.message !== "Promise was cancelled by user") {

--- a/src/lib/plot.test.ts
+++ b/src/lib/plot.test.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import { buildPlot } from "./plot";
+
+function check(
+  str: string,
+  deps: string[] = [],
+  result: string | undefined = undefined,
+) {
+  const context = (name: string) => `build('${str}').${name}`;
+  const plot = buildPlot(str);
+  expect(plot.ok, context("ok")).to.be.true;
+  if (plot.ok) {
+    expect(plot.deps, context("deps")).to.deep.eq(deps);
+    if (result) {
+      expect(plot.results, context("results")).to.deep.eq([result]);
+    }
+  }
+}
+
+function fail(str: string) {
+  const plot = buildPlot(str);
+  expect(plot.ok, `should not parse: '${str}'`).to.be.false;
+}
+
+describe("buildPlot", () => {
+  it("parses empty string", () => check(""));
+
+  it("parses a basic function", () => check("x => cool", ["x"]));
+
+  it("parses a two-arg function", () => check("(x, y) => x + y", ["x", "y"]));
+
+  it("parses a one-arg result", () =>
+    check("stuff = x => nice", ["x"], "stuff"));
+
+  it("parses a no-arg result", () =>
+    check("result = () => swanky", [], "result"));
+
+  it("parses an async function", () =>
+    check('_ = async () => import("lodash")', [], "_"));
+});

--- a/src/lib/plot.test.ts
+++ b/src/lib/plot.test.ts
@@ -17,11 +17,6 @@ function check(
   }
 }
 
-function fail(str: string) {
-  const plot = buildPlot(str);
-  expect(plot.ok, `should not parse: '${str}'`).to.be.false;
-}
-
 describe("buildPlot", () => {
   it("parses empty string", () => check(""));
 

--- a/src/lib/plot.worker.ts
+++ b/src/lib/plot.worker.ts
@@ -1,14 +1,21 @@
 import * as Plot from "@observablehq/plot";
 import domino from "domino";
+import { RenderedElement } from "./types";
 
 globalThis.document = domino.createDocument();
 
-onmessage = (event) => {
+onmessage = async (event) => {
   const { code, data } = event.data;
   const fn = new Function(
     "Plot",
-    "__percival_data",
-    `return (${code})(__percival_data);`,
+    "...__percival_data",
+    `return (${code})(...__percival_data);`,
   );
-  postMessage(fn(Plot, data).outerHTML);
+  let result = await fn(Plot, ...data);
+
+  if (result && "outerHTML" in result) {
+    result = RenderedElement(result);
+  }
+
+  postMessage(result);
 };

--- a/src/lib/runtime.test.ts
+++ b/src/lib/runtime.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import init from "percival-wasm";
 import { build } from "./runtime";
+import { Relation, type RelationSet } from "./types";
 
 async function checkProgram({
   src,
@@ -12,8 +13,8 @@ async function checkProgram({
   src: string;
   deps: string[];
   results: string[];
-  input: Record<string, object[]>;
-  output: Record<string, object[]>;
+  input: RelationSet;
+  output: RelationSet;
 }) {
   const result = build(src);
   expect(result.ok).to.be.true;
@@ -56,17 +57,17 @@ tc(x, y) :- tc(x, y: z), edge(x: z, y).
       deps: ["edge"],
       results: ["tc"],
       input: {
-        edge: [
+        edge: Relation([
           { x: 2, y: 3 },
           { x: 3, y: 4 },
-        ],
+        ]),
       },
       output: {
-        tc: [
+        tc: Relation([
           { x: 2, y: 3 },
           { x: 2, y: 4 },
           { x: 3, y: 4 },
-        ],
+        ]),
       },
     });
   });
@@ -81,16 +82,16 @@ tc(x, y) :- edge(x, y).
       deps: ["edge"],
       results: ["tc"],
       input: {
-        edge: [
+        edge: Relation([
           { x: "hello", y: "world" },
           { x: "world", y: "foo" },
           { x: "foo", y: "baz" },
           { x: "world", y: "bar" },
           { x: "alt-src", y: "foo" },
-        ],
+        ]),
       },
       output: {
-        tc: [
+        tc: Relation([
           { x: "hello", y: "world" },
           { x: "hello", y: "foo" },
           { x: "hello", y: "baz" },
@@ -101,7 +102,7 @@ tc(x, y) :- edge(x, y).
           { x: "alt-src", y: "foo" },
           { x: "alt-src", y: "baz" },
           { x: "foo", y: "baz" },
-        ],
+        ]),
       },
     });
   });
@@ -119,15 +120,15 @@ tc(x, y) :- tc(x, y: z), edge(x: z, y).
       results: ["edge", "tc"],
       input: {},
       output: {
-        edge: [
+        edge: Relation([
           { x: "foo", y: "bar" },
           { x: "bar", y: "baz" },
-        ],
-        tc: [
+        ]),
+        tc: Relation([
           { x: "foo", y: "bar" },
           { x: "foo", y: "baz" },
           { x: "bar", y: "baz" },
-        ],
+        ]),
       },
     });
   });
@@ -140,7 +141,7 @@ tc(x, y) :- tc(x, y: z), edge(x: z, y).
       results: ["ok"],
       input: {},
       output: {
-        ok: [{ x: true, y: false }],
+        ok: Relation([{ x: true, y: false }]),
       },
     });
   });
@@ -156,7 +157,7 @@ name(value: \`first + " " + last\`) :- person(first, last).
       deps: ["person"],
       results: ["name"],
       input: {
-        person: [
+        person: Relation([
           {
             first: "eric",
             last: "zhang",
@@ -165,10 +166,10 @@ name(value: \`first + " " + last\`) :- person(first, last).
             first: "john",
             last: "doe",
           },
-        ],
+        ]),
       },
       output: {
-        name: [{ value: "eric zhang" }, { value: "john doe" }],
+        name: Relation([{ value: "eric zhang" }, { value: "john doe" }]),
       },
     });
   });
@@ -189,7 +190,7 @@ fib(n: \`n + 1\`, x: \`x1 + x2\`) :-
       results: ["fib"],
       input: {},
       output: {
-        fib: [
+        fib: Relation([
           { n: 0, x: 0 },
           { n: 1, x: 1 },
           { n: 2, x: 1 },
@@ -201,7 +202,7 @@ fib(n: \`n + 1\`, x: \`x1 + x2\`) :-
           { n: 8, x: 21 },
           { n: 9, x: 34 },
           { n: 10, x: 55 },
-        ],
+        ]),
       },
     });
   });
@@ -233,7 +234,7 @@ describe("import directives", () => {
       results: ["crimea"],
       input: {},
       output: {
-        crimea: [
+        crimea: Relation([
           { date: "1854-04-01", wounds: 0, other: 110, disease: 110 },
           { date: "1854-05-01", wounds: 0, other: 95, disease: 105 },
           { date: "1854-06-01", wounds: 0, other: 40, disease: 95 },
@@ -258,7 +259,7 @@ describe("import directives", () => {
           { date: "1856-01-01", wounds: 0, other: 160, disease: 160 },
           { date: "1856-02-01", wounds: 0, other: 100, disease: 100 },
           { date: "1856-03-01", wounds: 0, other: 125, disease: 90 },
-        ],
+        ]),
       },
     });
   });
@@ -274,7 +275,7 @@ count(value: count[1] { iowa() }).
       results: ["iowa", "count"],
       input: {},
       output: {
-        count: [{ value: 51 }],
+        count: Relation([{ value: 51 }]),
       },
     });
   });
@@ -298,7 +299,7 @@ stats(count, max_wounds, min_wounds, total_wounds, mean_wounds) :-
       results: ["crimea", "stats"],
       input: {},
       output: {
-        stats: [
+        stats: Relation([
           {
             count: 24,
             max_wounds: 480,
@@ -306,7 +307,7 @@ stats(count, max_wounds, min_wounds, total_wounds, mean_wounds) :-
             total_wounds: 3770,
             mean_wounds: 3770 / 24,
           },
-        ],
+        ]),
       },
     });
   });
@@ -329,7 +330,7 @@ yearly_mpg(year, value) :-
       results: ["cars", "year", "yearly_mpg"],
       input: {},
       output: {
-        yearly_mpg: [
+        yearly_mpg: Relation([
           {
             value: 33.696551724137926,
             year: "1980-01-01",
@@ -378,7 +379,7 @@ yearly_mpg(year, value) :-
             value: 14.657142857142857,
             year: "1970-01-01",
           },
-        ],
+        ]),
       },
     });
   });
@@ -390,17 +391,17 @@ yearly_mpg(year, value) :-
       deps: ["vertex", "edge"],
       results: ["ok"],
       input: {
-        vertex: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
-        edge: [
+        vertex: Relation([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]),
+        edge: Relation([
           { from: 1, to: 3 },
           { from: 1, to: 2 },
           { from: 2, to: 4 },
           { from: 3, to: 3 },
           { from: 4, to: 1 },
-        ],
+        ]),
       },
       output: {
-        ok: [{ value: 10 }],
+        ok: Relation([{ value: 10 }]),
       },
     });
   });

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -1,15 +1,16 @@
 import { compile } from "percival-wasm";
 import Worker from "./runtime.worker?worker&inline";
+import type { RelationSet } from "./types";
 
 interface CancellablePromise<T> extends Promise<T> {
   cancel: () => void;
 }
 
-type EvalPromise = CancellablePromise<Record<string, object[]>>;
+type EvalPromise = CancellablePromise<RelationSet>;
 
 type CompilerResultOk = {
   ok: true;
-  evaluate: (deps: Record<string, object[]>) => EvalPromise;
+  evaluate: (deps: RelationSet) => EvalPromise;
   deps: string[];
   results: string[];
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,36 @@
+/** An entry in a relation. */
+export type Row = Record<string, unknown> & { __type__: "row" };
+
+/** A relation. */
+export type Relation = Array<Row>;
+
+/** Typecast an array of objects to a relation. */
+export function Relation(objs: object[]): Relation {
+  return objs as Relation;
+}
+
+/** A set of named relations, as eg the output of a cell. */
+export type RelationSet = Record<string, Relation>;
+
+const RenderedElementKey = "__percivalRenderedElement__";
+
+export type RenderedElement = {
+  [RenderedElementKey]: true;
+  outerHTML: string;
+};
+
+export function RenderedElement(elementLike: {
+  outerHTML: string;
+}): RenderedElement {
+  return {
+    [RenderedElementKey]: true,
+    outerHTML: elementLike.outerHTML,
+  };
+}
+
+export function isRenderedElement(value: unknown): value is RenderedElement {
+  return (
+    value instanceof Element ||
+    (typeof value === "object" && value !== null && RenderedElementKey in value)
+  );
+}


### PR DESCRIPTION
This PR updates Plot cells to work as more fully-featured JS cells. 

- Plot cells can take multiple input dependencies: `(dep1, dep2) => ...` or no inputs, `() => ...`.
- Plot cells can be async, allowing them to access modules with `await import(...)`: `async dep => (await import('https://esm.sh/...'))(dep)`.
- Plot cells can write a reactive result, using assignment syntax: `resultName = () => [{ x: 1 }, { x: 2 }]`. Currently this emits one relation, not a set of relations like code cells. A future change could use syntax like `{ table1, table2 } = () => ...` to emit multiple relation outputs.
- Cell outputs with `outerHTML` are rendered as HTML (as before). Array outputs are rendered as relations. Otherwise, the output is rendered as JSON. If #16 is merged, I'll replace the simple JSON renderer with the JSON tree inspector used there.

After these changes "plot" vs "code" seem like misnomers - perhaps we should rename these concepts to "datalog" and "js". However, that's a bigger policy/design change. 

<img width="746" alt="image" src="https://user-images.githubusercontent.com/296279/167271377-a4ccbc9e-9bba-4721-b719-0e45cffaa32c.png">
