### PR TITLE
Sidebar UX

### DIFF
--- a/src/components/Notebook.svelte
+++ b/src/components/Notebook.svelte
@@ -6,7 +6,7 @@
   export let notebook: NotebookState;
 </script>
 
-<div class="space-y-3 pt-8 pb-24 px-3">
+<div class="space-y-3 pt-8 pb-24 pl-6 pr-1">
   {#each [...notebook] as [id, cell] (id)}
     <CellDivider
       on:create={(event) => {

--- a/src/components/cell/Cell.svelte
+++ b/src/components/cell/Cell.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { fade } from "svelte/transition";
-  import FaChevronDown from "svelte-icons/fa/FaChevronDown.svelte";
   import FaChevronRight from "svelte-icons/fa/FaChevronRight.svelte";
   import FaTrashAlt from "svelte-icons/fa/FaTrashAlt.svelte";
 
@@ -12,23 +11,21 @@
   const dispatch = createEventDispatcher();
 
   export let state: CellState;
+
+  function toggleDisplayInput() {
+    dispatch("toggle");
+  }
 </script>
 
 <div class="cell" transition:fade>
-  <button class="sidebar" on:click={() => dispatch("toggle")}>
-    <div class="w-4 h-4">
-      {#if state.hidden}
-        <FaChevronRight />
-      {:else}
-        <FaChevronDown />
-      {/if}
+  <button class="sidebar" on:click={toggleDisplayInput}>
+    <div class="mb-3" class:rotate-90={!state.hidden}>
+      <FaChevronRight />
     </div>
     <button
-      class="w-4 h-4 text-gray-400 hover:text-red-600 transition-colors"
-      on:click={(event) => {
-        event.stopPropagation();
-        dispatch("delete");
-      }}
+      class="text-gray-400 hover:text-red-600 transition-colors"
+      class:hidden={state.hidden}
+      on:click|stopPropagation={() => dispatch("delete")}
     >
       <FaTrashAlt />
     </button>
@@ -39,7 +36,7 @@
 
 <style lang="postcss">
   .cell {
-    @apply relative min-h-[32px] my-0;
+    @apply relative min-h-[32px] my-0 pl-0.5;
   }
 
   .cell:hover .sidebar {
@@ -47,8 +44,14 @@
   }
 
   .sidebar {
-    @apply absolute h-full left-[-2000px] w-[2000px]
-      flex justify-end items-start space-x-2 py-2 pr-3
+    left: calc(-50vw + 50% - 0.6rem);
+    width: calc(50vw - 50% + 0.6rem);
+    @apply absolute h-full
+      flex flex-col justify-start items-end space-y-2 p-1 pt-2 border-r-2 hover:border-gray-300
       transition-all hover:bg-zinc-50 opacity-0 text-gray-400 hover:text-gray-800;
+  }
+
+  .sidebar > * {
+    @apply w-4 h-4 transition-all;
   }
 </style>


### PR DESCRIPTION
Orient sidebar buttons vertically, as described in https://github.com/ekzhang/percival/pull/16#issuecomment-1120137337. This will conflict with 16; that PR should probably be merged first and I'll rebase this one on top of it after.

Changes:
* Orient buttons vertically, with the chevron in the top right corner. This makes it easier to add more buttons, and also makes the buttons clickable on mobile.
* Adjust the spacing of the sidebar and Notebook so that the sidebar and buttons are always visible, even with a very narrow view. It's a tiny bit off-center at this width but worth actually being able to interact with the UI.
* Add small border to the right of the sidebar, visible on cell hover, and small cell padding left to space it. This makes it easier to see which input and output views are part of the same cell; this was visually confusing at first and will get worse as we add more views to cells.
* Remove FaChevronDown in favor of a conditional `rotate-90` transform class when the input is shown. Combined with `transition-all` this nicely animates the chevron when you click on the sidebar.
* Only show delete button when input is visible, this helps prevent taps on the invisible delete button on mobile (for closed cells at least), and works around an issue on closed markdown cells with one line where the delete button sticks out below the bottom of the sidebar.
* Adjust the positioning calculation of the sidebar so that the left side reaches just to the edge of the view, not far past. This will make it easier to position items in the sidebar in general, and covers the case where the page is very zoomed out and 2000px is not enough. Generally this is minor but feels more 'correct' to me.